### PR TITLE
Add data-driven board state model with FEN support

### DIFF
--- a/Bishop.cs
+++ b/Bishop.cs
@@ -16,38 +16,31 @@ public class Bishop : ChessPiece
     /// <returns>True if the piece can move to the specified position, false otherwise.</returns>
     public override bool CanMoveTo(int x, int y)
     {
-        ChessPiece targetPiece = ChessBoard.Instance.GetPiece(x, y);
-        if (targetPiece != null && targetPiece.Color == this.Color) return false;
+        if (BoardState == null || !BoardState.IsWithinBounds(x, y)) return false;
 
-        // Calculate the movement distance in x and y direction
         int deltaX = x - Position.x;
         int deltaY = y - Position.y;
 
-        // Check if the movement is diagonal
-        if (Mathf.Abs(deltaX) == Mathf.Abs(deltaY))
-        {
-            // Check if the diagonal path is clear
-            int xDir = (deltaX > 0) ? 1 : -1;
-            int yDir = (deltaY > 0) ? 1 : -1;
-            int xTest = Position.x + xDir;
-            int yTest = Position.y + yDir;
-            while (xTest != x && yTest != y)
-            {
-                if (ChessBoard.Instance.GetPiece(xTest, yTest) != null)
-                {
-                    return false;
-                }
-                xTest += xDir;
-                yTest += yDir;
-            }
+        if (deltaX == 0 && deltaY == 0) return false;
+        if (Mathf.Abs(deltaX) != Mathf.Abs(deltaY)) return false;
 
-            return true;
-        }
-        else
+        int stepX = deltaX > 0 ? 1 : -1;
+        int stepY = deltaY > 0 ? 1 : -1;
+
+        int xTest = Position.x + stepX;
+        int yTest = Position.y + stepY;
+        while (xTest != x && yTest != y)
         {
-            // Invalid move
-            return false;
+            if (BoardState.GetPiece(xTest, yTest).HasValue)
+            {
+                return false;
+            }
+            xTest += stepX;
+            yTest += stepY;
         }
+
+        PieceData? targetPiece = BoardState.GetPiece(x, y);
+        return !targetPiece.HasValue || targetPiece.Value.Color != PieceColour;
     }
    
 }

--- a/ChessPiece.cs
+++ b/ChessPiece.cs
@@ -10,6 +10,10 @@ public abstract class ChessPiece : MonoBehaviour
     public Color Color { get; set; }
     public bool HasMoved = false;
 
+    protected BoardState BoardState => ChessBoard.Instance != null ? ChessBoard.Instance.Model : null;
+    protected PieceColor PieceColour => Color == Color.white ? PieceColor.White : PieceColor.Black;
+    protected PieceData? CurrentPieceData => BoardState?.GetPiece(Position);
+
     /// <summary>
     /// Determines if the piece can move to the specified position on the chess board.
     /// </summary>

--- a/Core/BoardState.cs
+++ b/Core/BoardState.cs
@@ -1,0 +1,555 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Data model that tracks the state of the chess board without relying on MonoBehaviours.
+/// </summary>
+public class BoardState
+{
+    public const string StartingFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+
+    private readonly PieceData?[,] squares = new PieceData?[8, 8];
+
+    public PieceColor SideToMove { get; set; } = PieceColor.White;
+    public CastlingRights Castling { get; private set; } = CastlingRights.All;
+    public Vector2Int? EnPassantTarget { get; private set; }
+    public int HalfmoveClock { get; private set; }
+    public int FullmoveNumber { get; private set; } = 1;
+
+    public List<MoveRecord> MoveHistory { get; } = new List<MoveRecord>();
+
+    public BoardState()
+    {
+    }
+
+    private BoardState(BoardState other)
+    {
+        SideToMove = other.SideToMove;
+        Castling = other.Castling;
+        EnPassantTarget = other.EnPassantTarget;
+        HalfmoveClock = other.HalfmoveClock;
+        FullmoveNumber = other.FullmoveNumber;
+        MoveHistory.AddRange(other.MoveHistory);
+
+        for (int x = 0; x < 8; x++)
+        {
+            for (int y = 0; y < 8; y++)
+            {
+                squares[x, y] = other.squares[x, y];
+            }
+        }
+    }
+
+    public static BoardState CreateInitial()
+    {
+        var state = new BoardState();
+        state.LoadFromFen(StartingFen);
+        return state;
+    }
+
+    public BoardState Clone() => new BoardState(this);
+
+    public PieceData? GetPiece(int x, int y)
+    {
+        if (!IsWithinBounds(x, y)) return null;
+        return squares[x, y];
+    }
+
+    public PieceData? GetPiece(Vector2Int position) => GetPiece(position.x, position.y);
+
+    public void SetPiece(int x, int y, PieceData? piece)
+    {
+        if (!IsWithinBounds(x, y)) return;
+        squares[x, y] = piece;
+    }
+
+    public void SetPiece(Vector2Int position, PieceData? piece) => SetPiece(position.x, position.y, piece);
+
+    public bool IsWithinBounds(int x, int y) => x >= 0 && x < 8 && y >= 0 && y < 8;
+
+    public MoveRecord ApplyMove(Vector2Int from, Vector2Int to, PieceType? promotion = null)
+    {
+        PieceData? movingPiece = GetPiece(from);
+        if (!movingPiece.HasValue)
+            throw new InvalidOperationException("No piece exists on the origin square.");
+
+        PieceData movingData = movingPiece.Value;
+        MoveRecord record = new MoveRecord
+        {
+            From = from,
+            To = to,
+            MovingPiece = movingData,
+            Promotion = promotion
+        };
+
+        PieceData? capturedPiece = GetPiece(to);
+        Vector2Int? capturedPosition = null;
+
+        bool isEnPassantCapture = false;
+        if (movingData.Type == PieceType.Pawn && !capturedPiece.HasValue && EnPassantTarget.HasValue && EnPassantTarget.Value == to)
+        {
+            int direction = movingData.Color == PieceColor.White ? -1 : 1;
+            Vector2Int pawnToCapture = new Vector2Int(to.x, to.y + direction);
+            PieceData? enPassantPawn = GetPiece(pawnToCapture);
+            if (enPassantPawn.HasValue && enPassantPawn.Value.Type == PieceType.Pawn && enPassantPawn.Value.Color != movingData.Color)
+            {
+                capturedPiece = enPassantPawn;
+                capturedPosition = pawnToCapture;
+                SetPiece(pawnToCapture, null);
+                isEnPassantCapture = true;
+            }
+        }
+
+        if (capturedPiece.HasValue && !capturedPosition.HasValue)
+        {
+            capturedPosition = to;
+            SetPiece(to, null);
+        }
+
+        record.CapturedPiece = capturedPiece;
+        record.CapturedPosition = capturedPosition;
+        record.IsEnPassantCapture = isEnPassantCapture;
+
+        bool isCastling = movingData.Type == PieceType.King && Mathf.Abs(to.x - from.x) == 2;
+        if (isCastling)
+        {
+            int rookFromX = to.x > from.x ? 7 : 0;
+            int rookToX = to.x > from.x ? to.x - 1 : to.x + 1;
+            Vector2Int rookFrom = new Vector2Int(rookFromX, from.y);
+            Vector2Int rookTo = new Vector2Int(rookToX, from.y);
+
+            PieceData? rookData = GetPiece(rookFrom);
+            if (rookData.HasValue)
+            {
+                SetPiece(rookFrom, null);
+                PieceData movedRook = rookData.Value;
+                movedRook.HasMoved = true;
+                SetPiece(rookTo, movedRook);
+                record.IsCastling = true;
+                record.RookFrom = rookFrom;
+                record.RookTo = rookTo;
+            }
+        }
+
+        SetPiece(from, null);
+
+        PieceData updatedPiece = movingData;
+        updatedPiece.HasMoved = true;
+        if (promotion.HasValue)
+        {
+            updatedPiece.Type = promotion.Value;
+        }
+        SetPiece(to, updatedPiece);
+
+        UpdateCastlingRights(from, to, movingData, capturedPiece);
+        UpdateEnPassantTarget(from, to, movingData);
+        UpdateMoveCounters(movingData, capturedPiece.HasValue);
+
+        SideToMove = movingData.Color == PieceColor.White ? PieceColor.Black : PieceColor.White;
+
+        MoveHistory.Add(record);
+        return record;
+    }
+
+    private void UpdateCastlingRights(Vector2Int from, Vector2Int to, PieceData movingPiece, PieceData? capturedPiece)
+    {
+        if (movingPiece.Type == PieceType.King)
+        {
+            if (movingPiece.Color == PieceColor.White)
+            {
+                Castling = Castling.WithWhiteKingSide(false).WithWhiteQueenSide(false);
+            }
+            else
+            {
+                Castling = Castling.WithBlackKingSide(false).WithBlackQueenSide(false);
+            }
+        }
+        else if (movingPiece.Type == PieceType.Rook)
+        {
+            if (movingPiece.Color == PieceColor.White)
+            {
+                if (from.x == 0 && from.y == 0) Castling = Castling.WithWhiteQueenSide(false);
+                if (from.x == 7 && from.y == 0) Castling = Castling.WithWhiteKingSide(false);
+            }
+            else
+            {
+                if (from.x == 0 && from.y == 7) Castling = Castling.WithBlackQueenSide(false);
+                if (from.x == 7 && from.y == 7) Castling = Castling.WithBlackKingSide(false);
+            }
+        }
+
+        if (capturedPiece.HasValue && capturedPiece.Value.Type == PieceType.Rook)
+        {
+            if (capturedPiece.Value.Color == PieceColor.White)
+            {
+                if (to.x == 0 && to.y == 0) Castling = Castling.WithWhiteQueenSide(false);
+                if (to.x == 7 && to.y == 0) Castling = Castling.WithWhiteKingSide(false);
+            }
+            else
+            {
+                if (to.x == 0 && to.y == 7) Castling = Castling.WithBlackQueenSide(false);
+                if (to.x == 7 && to.y == 7) Castling = Castling.WithBlackKingSide(false);
+            }
+        }
+    }
+
+    private void UpdateEnPassantTarget(Vector2Int from, Vector2Int to, PieceData movingPiece)
+    {
+        if (movingPiece.Type == PieceType.Pawn && Mathf.Abs(to.y - from.y) == 2)
+        {
+            EnPassantTarget = new Vector2Int(from.x, (from.y + to.y) / 2);
+        }
+        else
+        {
+            EnPassantTarget = null;
+        }
+    }
+
+    private void UpdateMoveCounters(PieceData movingPiece, bool isCapture)
+    {
+        if (movingPiece.Type == PieceType.Pawn || isCapture)
+        {
+            HalfmoveClock = 0;
+        }
+        else
+        {
+            HalfmoveClock++;
+        }
+
+        if (movingPiece.Color == PieceColor.Black)
+        {
+            FullmoveNumber++;
+        }
+    }
+
+    public void LoadFromFen(string fen)
+    {
+        if (string.IsNullOrWhiteSpace(fen))
+            throw new ArgumentException("FEN string cannot be null or empty", nameof(fen));
+
+        string[] parts = fen.Split(' ');
+        if (parts.Length < 4)
+            throw new ArgumentException("FEN string must contain at least four parts", nameof(fen));
+
+        Clear();
+
+        string[] ranks = parts[0].Split('/');
+        if (ranks.Length != 8)
+            throw new ArgumentException("FEN placement data must have eight ranks", nameof(fen));
+
+        for (int rankIndex = 0; rankIndex < 8; rankIndex++)
+        {
+            string rank = ranks[rankIndex];
+            int file = 0;
+            foreach (char c in rank)
+            {
+                if (char.IsDigit(c))
+                {
+                    file += c - '0';
+                }
+                else
+                {
+                    if (file >= 8)
+                        throw new ArgumentException("FEN placement data is invalid", nameof(fen));
+
+                    PieceData piece = PieceData.FromFenChar(c);
+                    int y = 7 - rankIndex;
+                    SetPiece(file, y, piece);
+                    file++;
+                }
+            }
+
+            if (file != 8)
+                throw new ArgumentException("FEN rank does not contain eight squares", nameof(fen));
+        }
+
+        SideToMove = parts[1] == "w" ? PieceColor.White : PieceColor.Black;
+        Castling = CastlingRights.FromFen(parts[2]);
+        EnPassantTarget = parts[3] == "-" ? (Vector2Int?)null : ParseSquare(parts[3]);
+        HalfmoveClock = parts.Length > 4 ? int.Parse(parts[4]) : 0;
+        FullmoveNumber = parts.Length > 5 ? int.Parse(parts[5]) : 1;
+
+        InitializeHasMovedFlags();
+    }
+
+    private void Clear()
+    {
+        for (int x = 0; x < 8; x++)
+        {
+            for (int y = 0; y < 8; y++)
+            {
+                squares[x, y] = null;
+            }
+        }
+        MoveHistory.Clear();
+        Castling = CastlingRights.All;
+        SideToMove = PieceColor.White;
+        EnPassantTarget = null;
+        HalfmoveClock = 0;
+        FullmoveNumber = 1;
+    }
+
+    private void InitializeHasMovedFlags()
+    {
+        for (int x = 0; x < 8; x++)
+        {
+            for (int y = 0; y < 8; y++)
+            {
+                if (!squares[x, y].HasValue) continue;
+
+                PieceData piece = squares[x, y].Value;
+                switch (piece.Type)
+                {
+                    case PieceType.Pawn:
+                        int startRank = piece.Color == PieceColor.White ? 1 : 6;
+                        piece.HasMoved = y != startRank;
+                        break;
+                    case PieceType.Rook:
+                        piece.HasMoved = DetermineRookHasMoved(x, y, piece.Color);
+                        break;
+                    case PieceType.King:
+                        piece.HasMoved = DetermineKingHasMoved(piece.Color);
+                        break;
+                    default:
+                        piece.HasMoved = false;
+                        break;
+                }
+
+                squares[x, y] = piece;
+            }
+        }
+    }
+
+    private bool DetermineRookHasMoved(int x, int y, PieceColor colour)
+    {
+        if (colour == PieceColor.White)
+        {
+            if (x == 0 && y == 0) return !Castling.WhiteQueenSide;
+            if (x == 7 && y == 0) return !Castling.WhiteKingSide;
+        }
+        else
+        {
+            if (x == 0 && y == 7) return !Castling.BlackQueenSide;
+            if (x == 7 && y == 7) return !Castling.BlackKingSide;
+        }
+
+        return true;
+    }
+
+    private bool DetermineKingHasMoved(PieceColor colour)
+    {
+        if (colour == PieceColor.White)
+        {
+            return !(Castling.WhiteKingSide || Castling.WhiteQueenSide);
+        }
+        return !(Castling.BlackKingSide || Castling.BlackQueenSide);
+    }
+
+    public string ToFen()
+    {
+        List<string> ranks = new List<string>();
+        for (int rank = 7; rank >= 0; rank--)
+        {
+            int emptyCount = 0;
+            string rankString = string.Empty;
+            for (int file = 0; file < 8; file++)
+            {
+                PieceData? piece = squares[file, rank];
+                if (piece.HasValue)
+                {
+                    if (emptyCount > 0)
+                    {
+                        rankString += emptyCount.ToString();
+                        emptyCount = 0;
+                    }
+                    rankString += piece.Value.ToFenChar();
+                }
+                else
+                {
+                    emptyCount++;
+                }
+            }
+
+            if (emptyCount > 0)
+            {
+                rankString += emptyCount.ToString();
+            }
+
+            ranks.Add(rankString);
+        }
+
+        string placement = string.Join("/", ranks);
+        string side = SideToMove == PieceColor.White ? "w" : "b";
+        string castling = Castling.ToFen();
+        string enPassant = EnPassantTarget.HasValue ? FormatSquare(EnPassantTarget.Value) : "-";
+
+        return $"{placement} {side} {castling} {enPassant} {HalfmoveClock} {FullmoveNumber}";
+    }
+
+    private static Vector2Int ParseSquare(string square)
+    {
+        if (square.Length != 2)
+            throw new ArgumentException("Invalid en-passant square", nameof(square));
+
+        int file = square[0] - 'a';
+        int rank = square[1] - '1';
+        if (file < 0 || file > 7 || rank < 0 || rank > 7)
+            throw new ArgumentException("Invalid en-passant square", nameof(square));
+
+        return new Vector2Int(file, rank);
+    }
+
+    private static string FormatSquare(Vector2Int square)
+    {
+        char file = (char)('a' + square.x);
+        char rank = (char)('1' + square.y);
+        return $"{file}{rank}";
+    }
+}
+
+public enum PieceColor
+{
+    White,
+    Black
+}
+
+public enum PieceType
+{
+    Pawn,
+    Knight,
+    Bishop,
+    Rook,
+    Queen,
+    King
+}
+
+public struct PieceData
+{
+    public PieceType Type;
+    public PieceColor Color;
+    public bool HasMoved;
+
+    public static PieceData FromFenChar(char c)
+    {
+        PieceColor colour = char.IsUpper(c) ? PieceColor.White : PieceColor.Black;
+        PieceType type = char.ToLowerInvariant(c) switch
+        {
+            'p' => PieceType.Pawn,
+            'n' => PieceType.Knight,
+            'b' => PieceType.Bishop,
+            'r' => PieceType.Rook,
+            'q' => PieceType.Queen,
+            'k' => PieceType.King,
+            _ => throw new ArgumentException($"Invalid FEN character '{c}'")
+        };
+
+        return new PieceData
+        {
+            Type = type,
+            Color = colour,
+            HasMoved = false
+        };
+    }
+
+    public char ToFenChar()
+    {
+        char c = Type switch
+        {
+            PieceType.Pawn => 'p',
+            PieceType.Knight => 'n',
+            PieceType.Bishop => 'b',
+            PieceType.Rook => 'r',
+            PieceType.Queen => 'q',
+            PieceType.King => 'k',
+            _ => ' '
+        };
+
+        return Color == PieceColor.White ? char.ToUpperInvariant(c) : c;
+    }
+}
+
+public struct CastlingRights
+{
+    public bool WhiteKingSide;
+    public bool WhiteQueenSide;
+    public bool BlackKingSide;
+    public bool BlackQueenSide;
+
+    public static CastlingRights All => new CastlingRights
+    {
+        WhiteKingSide = true,
+        WhiteQueenSide = true,
+        BlackKingSide = true,
+        BlackQueenSide = true
+    };
+
+    public static CastlingRights FromFen(string fen)
+    {
+        if (fen == "-")
+            return new CastlingRights();
+
+        CastlingRights rights = new CastlingRights();
+        foreach (char c in fen)
+        {
+            switch (c)
+            {
+                case 'K': rights.WhiteKingSide = true; break;
+                case 'Q': rights.WhiteQueenSide = true; break;
+                case 'k': rights.BlackKingSide = true; break;
+                case 'q': rights.BlackQueenSide = true; break;
+                default: throw new ArgumentException($"Invalid castling rights character '{c}'");
+            }
+        }
+
+        return rights;
+    }
+
+    public CastlingRights WithWhiteKingSide(bool value)
+    {
+        WhiteKingSide = value;
+        return this;
+    }
+
+    public CastlingRights WithWhiteQueenSide(bool value)
+    {
+        WhiteQueenSide = value;
+        return this;
+    }
+
+    public CastlingRights WithBlackKingSide(bool value)
+    {
+        BlackKingSide = value;
+        return this;
+    }
+
+    public CastlingRights WithBlackQueenSide(bool value)
+    {
+        BlackQueenSide = value;
+        return this;
+    }
+
+    public string ToFen()
+    {
+        string fen = string.Empty;
+        if (WhiteKingSide) fen += "K";
+        if (WhiteQueenSide) fen += "Q";
+        if (BlackKingSide) fen += "k";
+        if (BlackQueenSide) fen += "q";
+        return string.IsNullOrEmpty(fen) ? "-" : fen;
+    }
+}
+
+public struct MoveRecord
+{
+    public Vector2Int From;
+    public Vector2Int To;
+    public PieceData MovingPiece;
+    public PieceData? CapturedPiece;
+    public Vector2Int? CapturedPosition;
+    public PieceType? Promotion;
+    public bool IsCastling;
+    public Vector2Int? RookFrom;
+    public Vector2Int? RookTo;
+    public bool IsEnPassantCapture;
+}

--- a/King.cs
+++ b/King.cs
@@ -13,21 +13,14 @@ public class King : ChessPiece
     /// <returns>True if the piece can move to the specified position, false otherwise.</returns>
     public override bool CanMoveTo(int x, int y)
     {
-        // Check if the target position is within the bounds of the board
-        if (x < 0 || x >= 8 || y < 0 || y >= 8) 
-            return false;
+        if (BoardState == null || !BoardState.IsWithinBounds(x, y)) return false;
 
-        // Check if the target position is already occupied by a friendly piece
-        ChessPiece targetPiece = ChessBoard.Instance.GetPiece(x, y);
-        if (targetPiece != null && targetPiece.Color == this.Color) return false;
+        PieceData? targetPiece = BoardState.GetPiece(x, y);
+        if (targetPiece.HasValue && targetPiece.Value.Color == PieceColour) return false;
 
-        // Check if the target position is one square away horizontally or vertically
         if (Mathf.Abs(x - Position.x) <= 1 && Mathf.Abs(y - Position.y) <= 1) return true;
 
-        // Check if the target position is a valid castling move
-        if (CanCastle(x, y)) return true;
-
-        return false;
+        return CanCastle(x, y);
     }
 
     /// <summary>
@@ -38,20 +31,35 @@ public class King : ChessPiece
     /// <returns><c>true</c> if the king and rook can castle to the specified position, otherwise <c>false</c>.</returns>
     private bool CanCastle(int x, int y)
     {
-        // Check if the king and rook involved in castling have not moved
-        if (HasMoved || ChessBoard.Instance.GetPiece(x, y) != null) return false;
+        if (BoardState == null) return false;
+        if (y != Position.y) return false;
+        if (Mathf.Abs(x - Position.x) != 2) return false;
+        if (BoardState.GetPiece(x, y).HasValue) return false;
 
-        // Check if the target position is two squares away horizontally
-        if (Mathf.Abs(x - Position.x) != 2 || Mathf.Abs(y - Position.y) != 0) return false;
+        PieceData? kingData = CurrentPieceData;
+        if (!kingData.HasValue || kingData.Value.HasMoved) return false;
 
-        // Check if there are no pieces between the king and rook
-        int rookX = x > Position.x ? 7 : 0;
-        ChessPiece rook = ChessBoard.Instance.GetPiece(rookX, Position.y);
-        if (rook == null || rook.GetType() != typeof(Rook) || rook.Color != Color || rook.HasMoved) return false;
+        bool castleKingSide = x > Position.x;
+
+        if (PieceColour == PieceColor.White)
+        {
+            if (castleKingSide && !BoardState.Castling.WhiteKingSide) return false;
+            if (!castleKingSide && !BoardState.Castling.WhiteQueenSide) return false;
+        }
+        else
+        {
+            if (castleKingSide && !BoardState.Castling.BlackKingSide) return false;
+            if (!castleKingSide && !BoardState.Castling.BlackQueenSide) return false;
+        }
+
+        int rookX = castleKingSide ? 7 : 0;
+        PieceData? rookData = BoardState.GetPiece(rookX, Position.y);
+        if (!rookData.HasValue || rookData.Value.Type != PieceType.Rook || rookData.Value.Color != PieceColour || rookData.Value.HasMoved)
+            return false;
 
         for (int i = Mathf.Min(Position.x, x) + 1; i < Mathf.Max(Position.x, x); i++)
         {
-            if (ChessBoard.Instance.GetPiece(i, Position.y) != null) return false;
+            if (BoardState.GetPiece(i, Position.y).HasValue) return false;
         }
 
         return true;

--- a/Knight.cs
+++ b/Knight.cs
@@ -15,22 +15,14 @@ public class Knight : ChessPiece
     /// <returns>True if the piece can move to the specified position, false otherwise.</returns>
     public override bool CanMoveTo(int x, int y)
     {
-        ChessPiece targetPiece = ChessBoard.Instance.GetPiece(x, y);
-        if (targetPiece != null && targetPiece.Color == this.Color) return false;
- 
-        // Calculate the movement distance in x and y direction
+        if (BoardState == null || !BoardState.IsWithinBounds(x, y)) return false;
+
+        PieceData? targetPiece = BoardState.GetPiece(x, y);
+        if (targetPiece.HasValue && targetPiece.Value.Color == PieceColour) return false;
+
         int deltaX = Mathf.Abs(x - Position.x);
         int deltaY = Mathf.Abs(y - Position.y);
 
-        // Check if the movement is valid (L-shape with length 2 and 1)
-        if ((deltaX == 1 && deltaY == 2) || (deltaX == 2 && deltaY == 1))
-        {
-            return true;
-        }
-        else
-        {
-            // Invalid move
-            return false;
-        }
+        return (deltaX == 1 && deltaY == 2) || (deltaX == 2 && deltaY == 1);
     }
 }

--- a/Queen.cs
+++ b/Queen.cs
@@ -15,50 +15,47 @@ public class Queen : ChessPiece
     /// <returns>True if the piece can move to the specified position, false otherwise.</returns>
     public override bool CanMoveTo(int x, int y)
     {
-        // Check if the move is diagonal
-        if (Mathf.Abs(x - Position.x) == Mathf.Abs(y - Position.y))
-        {
-            // Check if the path is clear
-            int dx = (x > Position.x) ? 1 : -1;
-            int dy = (y > Position.y) ? 1 : -1;
-            int steps = Mathf.Abs(x - Position.x);
-            for (int i = 1; i < steps; i++)
-            {
-                int checkX = Position.x + i * dx;
-                int checkY = Position.y + i * dy;
-                if (ChessBoard.Instance.GetPiece(checkX, checkY) != null)
-                {
-                    return false;
-                }
-            }
+        if (BoardState == null || !BoardState.IsWithinBounds(x, y)) return false;
 
-            // Check if the destination is empty or has an opposing piece
-            ChessPiece targetPiece = ChessBoard.Instance.GetPiece(x, y);
-            return targetPiece == null || targetPiece.Color != Color;
+        int deltaX = x - Position.x;
+        int deltaY = y - Position.y;
+
+        if (deltaX == 0 && deltaY == 0) return false;
+
+        bool isDiagonal = Mathf.Abs(deltaX) == Mathf.Abs(deltaY);
+        bool isStraight = deltaX == 0 || deltaY == 0;
+
+        if (!isDiagonal && !isStraight) return false;
+
+        int stepX = 0;
+        int stepY = 0;
+        int steps = 0;
+
+        if (isDiagonal)
+        {
+            stepX = deltaX > 0 ? 1 : -1;
+            stepY = deltaY > 0 ? 1 : -1;
+            steps = Mathf.Abs(deltaX);
         }
-        // Check if the move is vertical
-        else if (x == Position.x || y == Position.y)
+        else
         {
-            // Check if the path is clear
-            int dx = (x > Position.x) ? 1 : (x < Position.x) ? -1 : 0;
-            int dy = (y > Position.y) ? 1 : (y < Position.y) ? -1 : 0;
-            int steps = Mathf.Max(Mathf.Abs(x - Position.x), Mathf.Abs(y - Position.y));
-            for (int i = 1; i < steps; i++)
-            {
-                int checkX = Position.x + i * dx;
-                int checkY = Position.y + i * dy;
-                if (ChessBoard.Instance.GetPiece(checkX, checkY) != null)
-                {
-                    return false;
-                }
-            }
-
-            // Check if the destination is empty or has an opposing piece
-            ChessPiece targetPiece = ChessBoard.Instance.GetPiece(x, y);
-            return targetPiece == null || targetPiece.Color != Color;
+            stepX = deltaX == 0 ? 0 : (deltaX > 0 ? 1 : -1);
+            stepY = deltaY == 0 ? 0 : (deltaY > 0 ? 1 : -1);
+            steps = Mathf.Max(Mathf.Abs(deltaX), Mathf.Abs(deltaY));
         }
 
-        return false;
+        for (int i = 1; i < steps; i++)
+        {
+            int checkX = Position.x + i * stepX;
+            int checkY = Position.y + i * stepY;
+            if (BoardState.GetPiece(checkX, checkY).HasValue)
+            {
+                return false;
+            }
+        }
+
+        PieceData? targetPiece = BoardState.GetPiece(x, y);
+        return !targetPiece.HasValue || targetPiece.Value.Color != PieceColour;
     }
 
 

--- a/Rook.cs
+++ b/Rook.cs
@@ -16,41 +16,30 @@ public class Rook : ChessPiece
     /// <returns>True if the piece can move to the specified position, false otherwise.</returns>
     public override bool CanMoveTo(int x, int y)
     {
-        // Check if the target position is within the bounds of the board
-        if (x < 0 || x >= 8 || y < 0 || y >= 8)
-            return false;
+        if (BoardState == null || !BoardState.IsWithinBounds(x, y)) return false;
 
-        // Check if the destination is the same as the current position
-        if (x == Position.x && y == Position.y)
-        {
-            return false;
-        }
-
-        // Check if the destination is on the same row or column as the rook
-        if (x != Position.x && y != Position.y)
-        {
-            return false;
-        }
+        if (x == Position.x && y == Position.y) return false;
+        if (x != Position.x && y != Position.y) return false;
 
         int dx = x - Position.x;
         int dy = y - Position.y;
 
-        int signX = dx == 0 ? 0 : dx / Mathf.Abs(dx);
-        int signY = dy == 0 ? 0 : dy / Mathf.Abs(dy);
+        int stepX = dx == 0 ? 0 : dx / Mathf.Abs(dx);
+        int stepY = dy == 0 ? 0 : dy / Mathf.Abs(dy);
 
-        for (int i = 1; i < Mathf.Max(Mathf.Abs(dx), Mathf.Abs(dy)); i++)
+        int distance = Mathf.Max(Mathf.Abs(dx), Mathf.Abs(dy));
+        for (int i = 1; i < distance; i++)
         {
-            int checkX = Position.x + i * signX;
-            int checkY = Position.y + i * signY;
+            int checkX = Position.x + i * stepX;
+            int checkY = Position.y + i * stepY;
 
-            if (ChessBoard.Instance.GetPiece(checkX, checkY) != null)
+            if (BoardState.GetPiece(checkX, checkY).HasValue)
             {
                 return false;
             }
         }
 
-        // Check if the destination is occupied by a piece of the opposite color, or empty
-        ChessPiece pieceAtDestination = ChessBoard.Instance.GetPiece(x, y);
-        return pieceAtDestination == null || pieceAtDestination.Color != Color;
+        PieceData? destination = BoardState.GetPiece(x, y);
+        return !destination.HasValue || destination.Value.Color != PieceColour;
     }
 }


### PR DESCRIPTION
## Summary
- introduce a data-only `BoardState` model that tracks pieces, turn metadata, move history, and provides FEN import/export helpers
- rebuild `ChessBoard` setup and movement routines to synchronize MonoBehaviour pieces with the shared board state and expose FEN load/export methods
- update every piece `CanMoveTo` implementation to query occupancy and rights through the centralized model

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ddad0029ec8327a3747854736f6dee